### PR TITLE
Always match skip messsage case-insensitive

### DIFF
--- a/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketBranchCommitSkipTrait.java
+++ b/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketBranchCommitSkipTrait.java
@@ -78,7 +78,7 @@ public class BitbucketBranchCommitSkipTrait extends BranchCommitSkipTrait{
                     BitbucketBranch branch = branchesIterator.next();
                     if (branch.getName().equals(scmHead.getName())) {
                         String message = branch.getMessage();
-                        return super.containsSkipToken(message);
+                        return super.containsSkipToken(message.toLowerCase());
                     }
                 }
             }

--- a/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketCommitSkipTrait.java
+++ b/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketCommitSkipTrait.java
@@ -75,8 +75,8 @@ public class BitbucketCommitSkipTrait extends CommitSkipTrait{
                 while (pullIterator.hasNext()) {
                     BitbucketPullRequest pull = pullIterator.next();
                     if (pull.getSource().getBranch().getName().equals(scmHead.getName())) {
-                        String message = pull.getSource().getCommit().getMessage().toLowerCase();
-                        return super.containsSkipToken(message);
+                        String message = pull.getSource().getCommit().getMessage();
+                        return super.containsSkipToken(message.toLowerCase());
                     }
                 }
             }

--- a/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubBranchCommitSkipTrait.java
+++ b/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubBranchCommitSkipTrait.java
@@ -75,7 +75,7 @@ public class GitHubBranchCommitSkipTrait extends BranchCommitSkipTrait {
                     GHBranch branch = branchesIterator.next();
                     if ((branch.getName()).equals(scmHead.getName())) {
                         String message = ((GitHubSCMSourceRequest) scmSourceRequest).getRepository().getCommit(branch.getSHA1()).getCommitShortInfo().getMessage();
-                        return super.containsSkipToken(message);
+                        return super.containsSkipToken(message.toLowerCase());
                     }
                 }
             }

--- a/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubCommitSkipTrait.java
+++ b/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubCommitSkipTrait.java
@@ -74,8 +74,8 @@ public class GitHubCommitSkipTrait extends CommitSkipTrait {
                 while (pullIterator.hasNext()) {
                     GHPullRequest pull = pullIterator.next();
                     if (("PR-" + pull.getNumber()).equals(scmHead.getName())) {
-                        String message = pull.getHead().getCommit().getCommitShortInfo().getMessage().toLowerCase();
-                        return super.containsSkipToken(message);
+                        String message = pull.getHead().getCommit().getCommitShortInfo().getMessage();
+                        return super.containsSkipToken(message.toLowerCase());
                     }
                 }
             }


### PR DESCRIPTION
It was case-sensitive for branch messages.