### PR TITLE
Cleanup pom files

### DIFF
--- a/bitbucket-scm-trait-commit-skip/pom.xml
+++ b/bitbucket-scm-trait-commit-skip/pom.xml
@@ -38,25 +38,16 @@
             <artifactId>cloudbees-bitbucket-branch-source</artifactId>
             <version>${bitbucket-branch-source.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-trait-commit-skip-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>branch-api</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
-
 </project>

--- a/github-scm-trait-commit-skip/pom.xml
+++ b/github-scm-trait-commit-skip/pom.xml
@@ -26,7 +26,6 @@
     </dependencyManagement>
 
     <dependencies>
-
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-branch-source</artifactId>
@@ -37,10 +36,6 @@
             <artifactId>scm-trait-commit-skip-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>branch-api</artifactId>
-        </dependency>
 
         <!-- optional (maybe not so) dependency of git, needed to make InjectedTest works -->
         <dependency>
@@ -49,7 +44,6 @@
             <version>1.12.1</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/scm-trait-commit-skip-common/pom.xml
+++ b/scm-trait-commit-skip-common/pom.xml
@@ -11,39 +11,7 @@
     <artifactId>scm-trait-commit-skip-common</artifactId>
 
     <name>Commit Skip SCM Behaviour shared components</name>
-    <description>A single abstract class to refactor code</description>
-
-    <dependencies>
-
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git</artifactId>
-            <version>${git.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>branch-api</artifactId>
-        </dependency>
-
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <description>Common code that is used in other modules</description>
 
     <dependencyManagement>
         <dependencies>
@@ -59,4 +27,34 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>${git.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>branch-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
* branch-api is already a transitive dependency via scm-trait-commit-skip-common
* fix description of scm-trait-commit-skip-common
* consistently have <dependencyManagement> before <dependencies>
* don't use extra empty lines