### PR TITLE
Show behaviours in section 'Within repository' instead of 'Additional' / 'General'

### DIFF
--- a/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketBranchCommitSkipTrait.java
+++ b/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketBranchCommitSkipTrait.java
@@ -10,6 +10,7 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.trait.SCMBuilder;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceRequest;
+import jenkins.scm.impl.trait.Selection;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -36,7 +37,9 @@ public class BitbucketBranchCommitSkipTrait extends BranchCommitSkipTrait {
     /**
      * Our descriptor.
      */
-    @Extension @Symbol("bitbucketBranchCommitSkipTrait")
+    @Extension
+    @Selection
+    @Symbol("bitbucketBranchCommitSkipTrait")
     @SuppressWarnings("unused") // instantiated by Jenkins
     public static class DescriptorImpl extends BranchCommitSkipTraitDescriptorImpl {
 

--- a/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketCommitSkipTrait.java
+++ b/bitbucket-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketCommitSkipTrait.java
@@ -10,6 +10,7 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.trait.SCMBuilder;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceRequest;
+import jenkins.scm.impl.trait.Selection;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -36,7 +37,9 @@ public class BitbucketCommitSkipTrait extends CommitSkipTrait {
     /**
      * Our descriptor.
      */
-    @Extension @Symbol("bitbucketCommitSkipTrait")
+    @Extension
+    @Selection
+    @Symbol("bitbucketCommitSkipTrait")
     @SuppressWarnings("unused") // instantiated by Jenkins
     public static class DescriptorImpl extends CommitSkipTraitDescriptorImpl {
 

--- a/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubBranchCommitSkipTrait.java
+++ b/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubBranchCommitSkipTrait.java
@@ -6,6 +6,7 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.trait.SCMBuilder;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceRequest;
+import jenkins.scm.impl.trait.Selection;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.github_branch_source.BranchSCMHead;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMBuilder;
@@ -36,7 +37,9 @@ public class GitHubBranchCommitSkipTrait extends BranchCommitSkipTrait {
     /**
      * Our descriptor.
      */
-    @Extension @Symbol("gitHubBranchCommitSkipTrait")
+    @Extension
+    @Selection
+    @Symbol("gitHubBranchCommitSkipTrait")
     @SuppressWarnings("unused") // instantiated by Jenkins
     public static class DescriptorImpl extends BranchCommitSkipTraitDescriptorImpl {
 

--- a/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubCommitSkipTrait.java
+++ b/github-scm-trait-commit-skip/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubCommitSkipTrait.java
@@ -6,6 +6,7 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.trait.SCMBuilder;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceRequest;
+import jenkins.scm.impl.trait.Selection;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMBuilder;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSourceRequest;
@@ -36,7 +37,9 @@ public class GitHubCommitSkipTrait extends CommitSkipTrait {
     /**
      * Our descriptor.
      */
-    @Extension @Symbol("gitHubCommitSkipTrait")
+    @Extension
+    @Selection
+    @Symbol("gitHubCommitSkipTrait")
     @SuppressWarnings("unused") // instantiated by Jenkins
     public static class DescriptorImpl extends CommitSkipTraitDescriptorImpl {
 


### PR DESCRIPTION
That's the section used for "discover" and "selection" traits.

For details how the `@Selection` annotation is evaluated, see the "cloudbees-bitbucket-branch-source" plugin, classes BitbucketSCMSource and BitbucketSCMNavigator.