### PR TITLE
Improve wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Commit skip SCM filters
 
-This repo is a collection of traits for several SCM Jenkins plugins.
+This repository contains a collection of traits for several branch-source Jenkins plugins.
 
 It provides filters for
- - GitHub: Filtering pull requests 
+ - GitHub: Filtering pull requests
  - Bitbucket: Filtering pull requests
 
-
-The filtering will be performed matching the last commit message, applying it whether it contains the tags [skip ci] or [ci skip]. The check is case-insensitive.
+The filtering will be performed matching the last commit message, applying it whether it contains the patterns "[skip ci]" or "[ci skip]". The check is case-insensitive.

--- a/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/BranchCommitSkipTrait.java
+++ b/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/BranchCommitSkipTrait.java
@@ -22,7 +22,7 @@ public abstract class BranchCommitSkipTrait extends SCMSourceTrait {
 
         @Override
         public String getDisplayName() {
-            return "Commit message filtering behaviour (branches)";
+            return "Filter branches by commit message";
         }
 
         @Override

--- a/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/CommitSkipTrait.java
+++ b/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/CommitSkipTrait.java
@@ -22,7 +22,7 @@ public abstract class CommitSkipTrait extends SCMSourceTrait {
 
         @Override
         public String getDisplayName() {
-            return "Commit message filtering behaviour (pull requests)";
+            return "Filter pull requests by commit message";
         }
 
         @Override

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/BranchCommitSkipTrait/help.html
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/BranchCommitSkipTrait/help.html
@@ -1,3 +1,3 @@
 <div>
-    Defines whether a branch should be excluded. Will be so if the last commit contains the tags [ci skip] or [skip ci] (case insensitive).
+    Branches whose last commit's message contains (case insensitive) the pattern "[ci skip]" or "[skip ci]" will be ignored.
 </div>

--- a/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/CommitSkipTrait/help.html
+++ b/scm-trait-commit-skip-common/src/main/resources/org/jenkinsci/plugins/scm_filter/CommitSkipTrait/help.html
@@ -1,3 +1,3 @@
 <div>
-    Defines whether a pull request creation or sync should be excluded. Will be so if the last commit contains the tags [ci skip] or [skip ci] (case insensitive).
+    Pull requests whose last commit's message contains (case insensitive) the pattern "[ci skip]" or "[skip ci]" will be ignored.
 </div>


### PR DESCRIPTION
Don't use word "behaviour" as it is clear that it is a behaviour.

Use verb "Filter" as prefix (not noun "filtering" as postfix) to comply with other behaviours (e.g. "Filter by name..." from scm-api-plugin).

Use word "pattern" (not "tag") as users may be confused because git itself uses tags.

Quote the patterns to make clear that "[" and "]" have to be contained literally and are not just used as delimiters in the help itself.