### PR TITLE
Adding branch-api back as a dependency as this fixes a NoClassDefFoundError exception

### DIFF
--- a/bitbucket-scm-trait-commit-skip/pom.xml
+++ b/bitbucket-scm-trait-commit-skip/pom.xml
@@ -44,6 +44,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>branch-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>

--- a/github-scm-trait-commit-skip/pom.xml
+++ b/github-scm-trait-commit-skip/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>scm-trait-commit-skip-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>branch-api</artifactId>
+        </dependency>
 
         <!-- optional (maybe not so) dependency of git, needed to make InjectedTest works -->
         <dependency>

--- a/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/CommitMessageBranchBuildStrategy.java
+++ b/scm-trait-commit-skip-common/src/main/java/org/jenkinsci/plugins/scm_filter/CommitMessageBranchBuildStrategy.java
@@ -13,8 +13,6 @@ import jenkins.scm.api.SCMSourceOwner;
 
 /**
  * A strategy for avoiding automatic builds for commits with messages that contain a specific pattern.
- * <p>
- * This is similar to what {@link hudson.plugins.git.extensions.impl.MessageExclusion} does.
  */
 public abstract class CommitMessageBranchBuildStrategy extends BranchBuildStrategy {
 


### PR DESCRIPTION
The problem is better described at #14 .

When the branch-api dependency was removed the plugin start causing an exception on startup and is unable to load. Therefor, the filters won't appear to be used on the UI.

Adding the dependency back has fixed the issue.
Please consider merging and releasing a new version.

Thanks.